### PR TITLE
Fixed downloadInstallScripts function to replace variable in uri

### DIFF
--- a/routes/Deployment.js
+++ b/routes/Deployment.js
@@ -66,7 +66,9 @@ const downloadInstallScripts = async (installScripts, dir, variables) => {
         try {
             let updatedUri = script.Uri;
             for (const [key, value] of Object.entries(parsedVariables)) {
-                updatedUri = updatedUri.replace(new RegExp(`{{${key}}}`, 'g'), value);
+                const regex = new RegExp(`{{${key}}}`, 'g');
+                updatedUri = updatedUri.replace(regex, value);
+                log.info(updatedUri);
             }
             await downloadFile(updatedUri, dir, script.Path);
             log.info(`Successfully downloaded ${script.Path}`);


### PR DESCRIPTION
when we use papermc image to create/deploy the server it only change the `{{Version}}` and `{{Build}}` variable only 1 time (which means that the server jar file's uri will be like this `https://api.papermc.io/v2/projects/paper/versions/1.16.5/builds/794/downloads/paper-{{Version}}-{{Build}}.jar`) it is not changing `Version` and `Build` variable when they appear 2nd time. And because of this we got an error.
```error
10/04 11:04:50   info    Replaced Version with 1.16.5 in https://api.papermc.io/v2/projects/paper/versions/1.16.5/builds/{{Build}}/downloads/paper-{{Version}}-{{Build}}.jar
 10/04 11:04:50   info    Replaced Build with 794 in https://api.papermc.io/v2/projects/paper/versions/1.16.5/builds/794/downloads/paper-{{Version}}-{{Build}}.jar
 10/04 11:04:50   error   Failed to download server.jar: Failed to download server.jar: HTTP status code 400
```